### PR TITLE
Unify Javascript tag so there are not 2 Javascript filters

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -185,7 +185,7 @@
       }
     ], 
     "tags": [
-      "JavaScript"
+      "Javascript"
     ], 
     "icon_url": "", 
     "forks_count": 5, 
@@ -202,7 +202,7 @@
       }
     ], 
     "tags": [
-      "JavaScript", 
+      "Javascript", 
       "Redshift", 
       "re:tools"
     ], 
@@ -379,7 +379,7 @@
       }
     ], 
     "tags": [
-      "JavaScript"
+      "Javascript"
     ],  
     "icon_url": "", 
     "forks_count": 27, 


### PR DESCRIPTION
Currently there are 2 javascript filters, that is caused because there is a "JavaScript" and a "Javascript" tag.
This commit unifies all tags to "Javascript"
